### PR TITLE
fix: force pure-Python json to avoid WASM corruption

### DIFF
--- a/src/json_pure.py
+++ b/src/json_pure.py
@@ -1,0 +1,14 @@
+# Copyright 2025-2026 Trevor Lauder.
+# SPDX-License-Identifier: MIT
+
+"""Force pure-Python json under Pyodide to avoid WASM heap corruption."""
+
+import json
+
+json.scanner.make_scanner = json.scanner.py_make_scanner
+json.decoder.scanstring = json.decoder.py_scanstring
+json.encoder.c_make_encoder = None
+json.encoder.encode_basestring_ascii = json.encoder.py_encode_basestring_ascii
+json.encoder.encode_basestring = json.encoder.py_encode_basestring
+
+json._default_decoder = json.JSONDecoder()

--- a/src/worker.py
+++ b/src/worker.py
@@ -3,6 +3,8 @@
 
 """Cloudflare Worker entrypoint for the DNS-over-HTTPS proxy."""
 
+import json_pure  # noqa: F401, I001
+
 import base64
 from collections import OrderedDict
 import hmac


### PR DESCRIPTION
See https://github.com/cloudflare/workerd/issues/6624